### PR TITLE
add cache on filter component

### DIFF
--- a/apps/frontend/config/cache.yml
+++ b/apps/frontend/config/cache.yml
@@ -8,3 +8,7 @@ default:
 
 _menu:
   enabled: true
+
+_filtering:
+  enabled: true
+  contextual: true


### PR DESCRIPTION
Caching the filter component will help laoding the page in
50% less time.

In a local environnment, the home were loading in 98ms.
With the cache activated, the page loads in 40ms.

The component is cached according to the request parameters.

Blackfire before : 
![capture du 2015-11-28 15 04 45_blackfire_avant](https://cloud.githubusercontent.com/assets/320372/11452243/8cd23bfc-95e1-11e5-9648-997b73290689.png)

Blackfire after : 
![capture du 2015-11-28 15 04 26_blackfire_apres](https://cloud.githubusercontent.com/assets/320372/11452245/932ff688-95e1-11e5-9186-c0bc16cde922.png)

Blackfire delta : 
![capture du 2015-11-28 15 03 49_blackfire_delta](https://cloud.githubusercontent.com/assets/320372/11452247/9ab550ba-95e1-11e5-995d-08718a7612e5.png)

After testing this on prod : 

Webpagetest before : http://www.webpagetest.org/result/151128_Q5_G9C/
![capture du 2015-11-28 15 05 07_webpagetest_avant](https://cloud.githubusercontent.com/assets/320372/11452249/abdfe0d0-95e1-11e5-852f-29d6e6cc2718.png)

Webpagetest after : http://www.webpagetest.org/result/151128_NP_GAR/
![capture du 2015-11-28 15 05 40_webpagetest_apres](https://cloud.githubusercontent.com/assets/320372/11452254/beae7460-95e1-11e5-96fa-befd97019609.png)




