### PR TITLE
fix dbInfosFactory when host is not a string

### DIFF
--- a/lib/dbInfos/dbInfosFactory.class.php
+++ b/lib/dbInfos/dbInfosFactory.class.php
@@ -10,7 +10,7 @@ class dbInfosFactory
     $infos->setPassword($connection['password']);
     $dsn = $connection['dsn'];
     $matches = array();
-    preg_match('/:host=(\w*);dbname=(.*)/', $dsn, $matches);
+    preg_match('/:host=(.*);dbname=(.*)/', $dsn, $matches);
     $infos->setHost($matches[1]);
     $infos->setName($matches[2]);
     return $infos;


### PR DESCRIPTION
if we use 127.0.0.1 instead of localhost, the host and
database are not found, and cli scripts doesn't work.
 Changing the regexp fixes that.