### PR TITLE
on masque le bouton de login

### DIFF
--- a/apps/frontend/templates/layout.php
+++ b/apps/frontend/templates/layout.php
@@ -40,7 +40,7 @@
                                   'action_to' => 'list',
                               )) ?>
                           </div>
-                          <div id="user_infos">
+                          <div id="user_infos" style="display: none">
                               <div class="header-button">
                                   <?php if ($sf_user->isAuthenticated()): ?>
                                       <?php echo link_to('<i class="icon-signout"></i><br />Logout', url_for('@sf_guard_signout')); ?>


### PR DESCRIPTION
Il n'y a pas de fonctionnalité derrière, cela est pertubant.
En attendant de soit supprimer le code derrière ou d'implémenter la
fonctionnalité, on masque le bouton afin d'être moins perturbant.