### PR TITLE
correction suppression de la barre de filtre

### DIFF
--- a/apps/frontend/modules/tools/templates/blockersSuccess.php
+++ b/apps/frontend/modules/tools/templates/blockersSuccess.php
@@ -53,5 +53,8 @@ In the last two weeks:
 
 <?php use_helper('JavascriptBase') ?>
 <?php echo javascript_tag() ?>
-  $('#filtering-border').remove();
+    var element = document.querySelector('#filtering-border');
+    if (element) {
+        element.parentNode.removeChild(element);
+    }
 <?php end_javascript_tag() ?>

--- a/apps/frontend/modules/tools/templates/highPrioritySuccess.php
+++ b/apps/frontend/modules/tools/templates/highPrioritySuccess.php
@@ -53,5 +53,8 @@ In the last two weeks:
 
 <?php use_helper('JavascriptBase') ?>
 <?php echo javascript_tag() ?>
-  $('#filtering-border').remove();
+    var element = document.querySelector('#filtering-border');
+    if (element) {
+        element.parentNode.removeChild(element);
+    }
 <?php end_javascript_tag() ?>

--- a/apps/frontend/modules/tools/templates/listRpmsForQaBugSuccess.php
+++ b/apps/frontend/modules/tools/templates/listRpmsForQaBugSuccess.php
@@ -94,7 +94,8 @@ endforeach;
   
 <?php use_helper('JavascriptBase') ?>
 <?php echo javascript_tag() ?>
-  $('#filtering-border').remove();
+    var element = document.querySelector('#filtering-border');
+    if (element) {
+        element.parentNode.removeChild(element);
+    }
 <?php end_javascript_tag() ?>
-  
-  

--- a/apps/frontend/modules/tools/templates/milestoneSuccess.php
+++ b/apps/frontend/modules/tools/templates/milestoneSuccess.php
@@ -52,5 +52,9 @@ In the last two weeks:
 
 <?php use_helper('JavascriptBase') ?>
 <?php echo javascript_tag() ?>
-  $('#filtering-border').remove();
+    var element = document.querySelector('#filtering-border');
+    if (element) {
+        element.parentNode.removeChild(element);
+    }
 <?php end_javascript_tag() ?>
+

--- a/apps/frontend/modules/tools/templates/securitySuccess.php
+++ b/apps/frontend/modules/tools/templates/securitySuccess.php
@@ -81,5 +81,8 @@ Number: <?php echo $count['total'] ?>
 
 <?php use_helper('JavascriptBase') ?>
 <?php echo javascript_tag() ?>
-  $('#filtering-border').remove();
+    var element = document.querySelector('#filtering-border');
+    if (element) {
+        element.parentNode.removeChild(element);
+    }
 <?php end_javascript_tag() ?>

--- a/apps/frontend/modules/tools/templates/updatesSuccess.php
+++ b/apps/frontend/modules/tools/templates/updatesSuccess.php
@@ -190,5 +190,8 @@ Number of validated backports: <?php echo $count['total'] ?>
 
 <?php use_helper('JavascriptBase') ?>
 <?php echo javascript_tag() ?>
-  $('#filtering-border').remove();
+    var element = document.querySelector('#filtering-border');
+    if (element) {
+        element.parentNode.removeChild(element);
+    }
 <?php end_javascript_tag() ?>


### PR DESCRIPTION
Nous pouvions avoir cette erreur js sur les pages de la partie "Tools"
pour lesquelles nous voulions supprimer la barre d filtre :

```
ReferenceError: $ is not defined
```

Cela car le fichier js est chargé de façon asynchrone et que
le bout de js qui supprimais la barre de filtre était executé possiblement
avant qu'il soit chargé.

On passe donc cette suppression en vanilla pour ne pas avoir
besoin de charger jQuery.