### PR TITLE
ajout de tests suite à la correction d'une erreur js

### DIFF
--- a/cypress/integration/section_tools.feature
+++ b/cypress/integration/section_tools.feature
@@ -12,12 +12,11 @@ Feature: Tools
     When I click on the link "QA Updates"
     Then I should see "QA team waiting for packager feedback"
 
-    # Il a des erreurs JS sur cette page, on ajoute donc pas de test pour le moment
-#  Scenario: I can go to the release blockers page
-#
-#    Given I go to the page "/"
-#    When I click on the link "Release blockers for Mga 8"
-#    Then I should see "This page lists all bug reports that have been marked as release blockers"
+  Scenario: I can go to the release blockers page
+
+    Given I go to the page "/"
+    When I click on the link "Release blockers for Mga 8"
+    Then I should see "This page lists all bug reports that have been marked as release blockers"
 
   Scenario: I can go to the Intended for page
 
@@ -25,9 +24,8 @@ Feature: Tools
     When I click on the link "Intended for Mga 8"
     Then I should see "This page lists all bug reports that have been marked as intented for next release, except release blockers"
 
-# Il a des erreurs JS sur cette page, on ajoute donc pas de test pour le moment
-#  Scenario: I can go to the High priority page
-#
-#    Given I go to the page "/"
-#    When I click on the link "High priority for Mga 8"
-#    Then I should see "This page lists all bug reports that have been marked with a high priority"
+  Scenario: I can go to the High priority page
+
+    Given I go to the page "/"
+    When I click on the link "High priority for Mga 8"
+    Then I should see "This page lists all bug reports that have been marked with a high priority"


### PR DESCRIPTION
Il y avait une erreur js empêchant la création de tests,
qui a été corrigé dans la PR https://github.com/agallou/mageia-app-db/pull/279

On peux donc activer les tests sur les pages en question.